### PR TITLE
Fix some CoffeeScript to ES6 porting bugs + nits

### DIFF
--- a/app/chrome/helpers/format.es6
+++ b/app/chrome/helpers/format.es6
@@ -8,9 +8,9 @@ let thresholds = [
 ];
 
 function format_bytes (bytes) {
-    for (var [label, min] in thresholds) {
+    for (let [label, min] of thresholds) {
       if (bytes >= min) {
-        return `${_str.numberFormat(bytes / min)}${label}`;
+        return `${_str.numberFormat(bytes / min)} ${label}`;
       }
     }
 

--- a/app/main.es6
+++ b/app/main.es6
@@ -2,7 +2,7 @@
 try {
   require("source-map-support").install();
 } catch (e) {
-  console.log("Failed to install source map support:\n#{e}");
+  console.log(`Failed to install source map support:\n${e}`);
 }
 
 require("./metal/crash_reporter").install();

--- a/app/metal/db.es6
+++ b/app/metal/db.es6
@@ -24,7 +24,7 @@ function is_date (name) {
 function to_date (text) {
   let matches = text.match(/^(\d+)-(\d+)-(\d+) (\d+):(\d+):(\d+)(\.\d*)?$/);
   if (!matches) {
-    throw new Error("Invalid date: #{text}");
+    throw new Error(`Invalid date: ${text}`);
   }
   let [, year, month, day, hour, min, sec] = matches;
   return new Date(Date.UTC(year, month - 1, day, hour, min, sec));

--- a/app/metal/launcher.es6
+++ b/app/metal/launcher.es6
@@ -27,7 +27,7 @@ function sh (exe_path, cmd) {
       cwd
     }, (error, stdout, stderr) => {
       if (error) {
-        console.log("#{exe_path} returned #{error}");
+        console.log(`${exe_path} returned ${error}`);
         console.log("stdout: ");
         console.log(stdout);
         console.log("stderr: ");
@@ -41,7 +41,7 @@ function sh (exe_path, cmd) {
 }
 
 function escape (arg) {
-  return '"' + arg.replace(/"/g, "\\\"") + '"';
+  return `"${arg.replace(/"/g, "\\\"")}"`;
 }
 
 export function launch (exe_path, args=[]) {

--- a/app/metal/setup.es6
+++ b/app/metal/setup.es6
@@ -47,12 +47,12 @@ export function run() {
       });
 
       r.on('error', (e) => {
-        reject("7-zip download failed with:\n#{e}\nTry again later!");
+        reject(`7-zip download failed with:\n${e}\nTry again later!`);
       });
 
       r.on('response', (response) => {
         if (!/^2/.test(""+response.statusCode)) {
-          reject("Could not download 7-zip, server error #{response.statusCode}\nTry again later!");
+          reject(`Could not download 7-zip, server error ${response.statusCode}\nTry again later!`);
         }
       });
 

--- a/app/metal/stores/app_store.es6
+++ b/app/metal/stores/app_store.es6
@@ -99,7 +99,7 @@ function fetch_games() {
         db.find({_table: 'games', user_id: own_id}).then(Immutable).then((games) => {
           if (state.library.panel != "dashboard") return;
           merge_state({library: {games}});
-          AppStore.emit_change()
+          AppStore.emit_change();
         });
       }
 
@@ -123,7 +123,7 @@ function fetch_games() {
         }).then(Immutable).then((games) => {
           if (state.library.panel != "owned") return
           merge_state({library: {games}});
-          AppStore.emit_change()
+          AppStore.emit_change();
         });
       }
 
@@ -212,13 +212,13 @@ function login_key (key) {
     merge_state({login: {errors}});
   }).finally(() =>{
     merge_state({login: {loading: false}});
-    AppStore.emit_change()
+    AppStore.emit_change();
   });
 }
 
 function login_with_password (username, password) {
   merge_state({login: {loading: true}});
-  AppStore.emit_change()
+  AppStore.emit_change();
 
   api.client.login_with_password(username, password).then((res) => {
     defer(() => {

--- a/app/metal/stores/install_store.es6
+++ b/app/metal/stores/install_store.es6
@@ -238,8 +238,8 @@ class AppInstall {
     });
 
     r.on('progress', (state) => {
-      this.progress = 0.01 * state.percent
-      this.emit_change()
+      this.progress = 0.01 * state.percent;
+      this.emit_change();
     });
 
     mkdirp.sync(path.dirname(this.archive_path));


### PR DESCRIPTION
Hey! So I took a little look around in the app and some of its code. Nice to see you switched to ES6 (just a step away from TypeScript, maybe! ^_^). Very excited to see it all mature into a fully-fledged itch.io app :)

Anyway, we ported of loooot of CoffeeScript to TypeScript in Superpowers a few months ago so I remembered some of the usual gotchas and went looking for them.
- Found a few template strings that needed to be updated (`"#{goodOldCoffeeScript}"` to ``${shinyES6}``)
- There was a `for (... in ...)` that should be `for (... of ...)` in `format.es6` but it looks like this code isn't used at the moment.
- Added a few semicolons

Hope you dig it! Let me know if there are any changes you don't like and I'll happily fix up the PR.
