### PR TITLE
Improve installation steps on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ goal is not to replace the itch.io website.
 itch is built in HTML/SCSS/ES6 and runs inside of Electron. Install the
 following to get started with development:
 
-* Install [Node.js](https://nodejs.org/). Tests aren't working with 0.12.* versions.
+* Install [Node.js](https://nodejs.org/) 4.2.x+.
 * Install [Electron](https://github.com/atom/electron):
 
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ goal is not to replace the itch.io website.
 itch is built in HTML/SCSS/ES6 and runs inside of Electron. Install the
 following to get started with development:
 
-* Install [Node.js](https://nodejs.org/)
+* Install [Node.js](https://nodejs.org/). Tests aren't working with 0.12.* versions.
 * Install [Electron](https://github.com/atom/electron):
 
 ```
@@ -27,6 +27,8 @@ npm install -g electron-prebuilt@0.35.4
 ```
 
 **N.B: 0.36.0 is known not to work with itch, 0.35.4 is the recommended release**
+
+* Install [sassc](https://github.com/sass/sassc) following the instructions for [Unix](https://github.com/sass/sassc/blob/master/docs/building/unix-instructions.md) or [Windows](https://github.com/sass/sassc/blob/master/docs/building/windows-instructions.md). Make sure it's in your `$PATH`.
 
 Check out this repository
 


### PR DESCRIPTION
Hi again @fasterthanlime. Another quick one.

I put a note regarding Node version because it doesn't runs the tests under 0.12.\* Node versions. I think is related with ES6 and how tests are written. `SyntaxError: Unexpected strict mode reserved word` ("let" in runner.js:5).

Of course change it as you desire. Just my 2cents regarding installation/pre-requirements.
