### PR TITLE
add platform icons to GameCell

### DIFF
--- a/app/components/game-list.js
+++ b/app/components/game-list.js
@@ -7,10 +7,18 @@ let PropTypes = require('react').PropTypes
 let Component = require('./component')
 
 let AppActions = require('../actions/app-actions')
+let os = require('../util/os')
 
 let misc = require('./misc')
 let TaskIcon = misc.TaskIcon
 let Icon = misc.Icon
+
+let platform_data = mori.toClj({
+  p_android: {icon: 'android', platform: 'android'},
+  p_windows: {icon: 'windows8', platform: 'windows'},
+  p_linux: {icon: 'tux', platform: 'linux'},
+  p_osx: {icon: 'apple', platform: 'osx'}
+})
 
 class GameCell extends Component {
   render () {
@@ -41,6 +49,15 @@ class GameCell extends Component {
       button_style.backgroundImage = `-webkit-linear-gradient(left, ${done_color}, ${done_color} ${percent}, ${undone_color} ${percent}, ${undone_color})`
     }
 
+    let platform_list = mori.reduceKV((l, platform, data) => {
+      if (mori.get(this.props.game, platform)) {
+        let is_active = os.itch_platform() == mori.get(data, 'platform')
+        let className = `icon icon-${mori.get(data, 'icon')}` + (is_active ? ' active' : '')
+        l.push(r.span({ className }))
+      }
+      return l
+    }, [], platform_data)
+
     return (
       r.div({className: 'game_cell'}, [
         r.div({className: 'bordered'}, [
@@ -61,7 +78,10 @@ class GameCell extends Component {
                 shell.openExternal(mori.get(game, 'url'))
               }
             }
-          })
+          }),
+          (platform_list.length
+          ? r.div({className: 'platforms'}, platform_list)
+          : '')
         ]),
         r.div({className: 'game_title'}, title),
         (user

--- a/app/style/main/library.scss
+++ b/app/style/main/library.scss
@@ -208,6 +208,26 @@ $cell_height: $cell_width * $cell_ratio;
       overflow: hidden;
     }
 
+    .platforms {
+      background-color: #000;
+      height: 30px;
+      position: relative;
+      margin-top: $cell_height - 30;
+      float: right;
+      padding-left: 5px;
+      padding-right: 5px;
+      padding-top: 5px;
+      border-radius: 3px;
+
+      .icon {
+          padding-left: 2px;
+          padding-right: 2px;
+      }
+      .active {
+        color: #68DAFF
+      }
+    }
+
     .game_thumb {
       @include transition(opacity .2s ease-in-out);
 

--- a/test/components/game-list-spec.js
+++ b/test/components/game-list-spec.js
@@ -29,7 +29,11 @@ test('game-list', t => {
       cover_url: 'b',
       user: {
         display_name: 'd'
-      }
+      },
+      p_android: true,
+      p_windows: true,
+      p_linux: true,
+      p_osx: true
     })
     let install = null
 


### PR DESCRIPTION
This adds a bar of platform icons to each game cover (if the game specifies any platforms). The current platform is highlighted for an easy overview of installable games. This should probably also be implemented as a category (see #130).
![](https://cloud.githubusercontent.com/assets/3913977/11819201/df23cf8a-a35e-11e5-81b1-431af3e65420.png)

let me know if there are any conventions I didn't follow. I'm quite new to electron.
