### PR TITLE
Display 'username or e-mail' instead of 'username' only in login field

### DIFF
--- a/app/static/locales/en.json
+++ b/app/static/locales/en.json
@@ -26,7 +26,7 @@
     "login.action.register": "Register", 
     "login.action.reset_password": "Forgot password", 
     "login.field.password": "Password", 
-    "login.field.username": "Username", 
+    "login.field.username": "Username or e-mail", 
     "login.status.dependency_check": "Making sure we have everything set up...", 
     "login.status.dependency_install": "Installing dependency {{name}} {{version}}", 
     "login.status.login": "Logging you in...", 

--- a/app/static/locales/fr.json
+++ b/app/static/locales/fr.json
@@ -26,7 +26,7 @@
     "login.action.register": "Inscription", 
     "login.action.reset_password": "Mot de passe oublié ?", 
     "login.field.password": "Mot de passe", 
-    "login.field.username": "Nom d'utilisateur", 
+    "login.field.username": "Nom d'utilisateur or e-mail", 
     "login.status.dependency_check": "Vérifications de dernière minute…", 
     "login.status.dependency_install": "Installation du composant {{name}} {{version}}", 
     "login.status.login": "Connexion en cours...", 


### PR DESCRIPTION
Hi all,

I thought it would be better to let the user know it can be possible to login using both username or e-mail. I made some changes to the locales displayed to reflect that. I have only updated English and French locales, as I am fluent in those languages.

This project is great!
