### PR TITLE
Fix GameCell may_download property setting to object

### DIFF
--- a/appsrc/components/game-list.js
+++ b/appsrc/components/game-list.js
@@ -25,7 +25,7 @@ class GameList extends ShallowComponent {
     let make_cell = (game) => {
       let game_id = mori.get(game, 'id')
       let cave = mori.get(caves_by_game_id, game_id)
-      let owned = mori.get(owned_games_by_id, game_id.toString()) ||
+      let owned = mori.get(owned_games_by_id, game_id.toString()) != null ||
         (is_press && mori.get(game, 'in_press_system'))
       if (!pred(cave)) {
         console.log(`failed predicate, skipping: `, mori.toJs(cave))


### PR DESCRIPTION
This causes the `may_download` property of the `GameCell` component to always be set to a meaningful boolean.

While going to any page with a games list, I kept noticing this warning and also logged the property.

![itch_proptype_warning](https://cloud.githubusercontent.com/assets/4426398/12472214/5da72c66-bfcb-11e5-9a28-899072eff0dd.jpg)

The first `may_download` property belongs to a game that I do own while the second property belongs to one that I do not own. Turns out that an earlier variable (`owned` in `games-list.js`) would get set to a mori hashMap if you actually owned the game. This PR just makes sure that if you do own the game that variable gets set to the boolean `true` instead of that object.
