### PR TITLE
Fix link to code style in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ possible with your report. If you can, please include:
 ## Submitting Pull Requests
 
 * Include screenshots and animated GIFs in your pull request whenever possible.
-* Follow the [coding style defined in docs](/docs/development/coding-style.md).
+* Follow the [coding style defined in docs](/docs/hacking/coding-style.md).
 * Write documentation in [Markdown](https://daringfireball.net/projects/markdown).
 * Use short, present tense commit messages. See [Commit Message Styleguide](#git-commit-messages).
 


### PR DESCRIPTION
Hi there. I'd been wanting to contribute back to itch.io for some time, and found the link to the code style guide was broken when I was reading the contributing guidelines. I _think_ I linked it to the correct page now, though I'm not entirely sure.
