### PR TITLE
macOS: fix `Info.plist` name in a sandbox for case-sensitive filesystem

### DIFF
--- a/appsrc/util/sandbox/darwin.js
+++ b/appsrc/util/sandbox/darwin.js
@@ -83,11 +83,11 @@ sandbox-exec -f ${spawn.escapePath(sandboxProfilePath)} ${spawn.escapePath(fullE
     )
 
     await sf.symlink(
-      ospath.join(realApp, 'Contents', 'Info.pList'),
-      ospath.join(fakeApp, 'Contents', 'Info.pList')
+      ospath.join(realApp, 'Contents', 'Info.plist'),
+      ospath.join(fakeApp, 'Contents', 'Info.plist')
     )
   } else {
-    await sf.writeFile(ospath.join(fakeApp, 'Contents', 'Info.pList'),
+    await sf.writeFile(ospath.join(fakeApp, 'Contents', 'Info.plist'),
       `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">


### PR DESCRIPTION
Symptom of the problem: game on macOS either refuses to start under itch sandbox (with message `The application cannot be opened because its executable is missing.`) or starts with missing icon. Without sandbox it runs perfectly.

The reason: currently itch symlinks `Info.pList` file from app bundle (in case app is a bundle) or creates `Info.pList` file by itself (in case app is not a bundle). But OS is actually looking for file `Info.plist`. By default filesystems on Macs are case-insensitive, so everything works fine on most systems. But my system happens to use case-sensitive filesystem (which is viable option offered by OS X installer, and it worked flawlessly for me so far). Therefore what happens next is:
1. System cannot find `Info.plist` in a "fake app bundle" created by itch.
2. If app's executable name is the same as bundle's name, then apparently system is still able to start app without `Info.plist`, but it will miss any custom metadata from `Info.plist`, such as app's icon.
3. If app's executable name is not the same as bundle's name, then system doesn't know how to start it and returns the error above.

Fix is simple: use correct case.
