### PR TITLE
:clap: Sort library items by last played.

### DIFF
--- a/appsrc/components/library.js
+++ b/appsrc/components/library.js
@@ -8,7 +8,7 @@ import GameGridFilters from './game-grid-filters'
 import {map, filter, indexBy, sortBy} from 'underline'
 
 // sort by last played, or install date if never opened
-const recency = (x) => -(new Date(x.lastTouched)) || -(new Date(x.installedAt)) || 0
+const recency = (x) => -(new Date(x.lastTouched || x.installedAt)) || 0
 
 export class Library extends Component {
   render () {

--- a/appsrc/components/library.js
+++ b/appsrc/components/library.js
@@ -7,7 +7,8 @@ import GameGrid from './game-grid'
 import GameGridFilters from './game-grid-filters'
 import {map, filter, indexBy, sortBy} from 'underline'
 
-const recency = (x) => -(new Date(x.installedAt)) || 0
+// sort by last played, or install date if never opened
+const recency = (x) => -(new Date(x.lastTouched)) || -(new Date(x.installedAt)) || 0
 
 export class Library extends Component {
   render () {


### PR DESCRIPTION
Hey! Love your work etc. :grin:

Now that I've started to grow my itch library a bit I've been finding it unintuitive to have to scroll down a little on the library view to play the game I'm currently working my way through (you can beat Overland, yes?) Seems like currently games are simply sorted by when you installed them, which means that games you bought a while back but are still playing can be pushed pretty far down the list.

Just a quick PR to instead sort by last played rather than install date (with install date being a fallback if the game has never been opened). Leaving it up to your UX consideration!

Cheers, keep up the good work. 👍
