### PR TITLE
Show the correct date in the version tooltip

### DIFF
--- a/appsrc/components/game-actions/list-secondary-actions.js
+++ b/appsrc/components/game-actions/list-secondary-actions.js
@@ -120,7 +120,7 @@ export default function listSecondaryActions (props) {
       version += ` #${cave.uploadId}`
     }
 
-    const hint = `${format.date(cave.installedArchiveMtime, DATE_FORMAT, t.lang)}`
+    const hint = `${format.date(upload.build.updatedAt, DATE_FORMAT, t.lang)}`
 
     items.push({
       type: 'info',


### PR DESCRIPTION
I hope that `build.updatedAt` is the correct one.
