### PR TITLE
:clap: Make 'default install location' clearer in preferences UI

### DIFF
--- a/appsrc/components/preferences.js
+++ b/appsrc/components/preferences.js
@@ -188,6 +188,10 @@ export class Preferences extends Component {
         <td className='action path' onClick={(e) => makeInstallLocationDefault(name)}>
           <div className='default-switch hint--right' data-hint={t('preferences.install_location.' + (isDefault ? 'is_default' : 'make_default'))}>
             <span className='single-line'>{path}</span>
+            {isDefault
+              ? <span className='single-line default-state'>(default location)</span>
+              : null
+            }
           </div>
         </td>
         <td> {humanize.fileSize(size)} </td>

--- a/appsrc/components/preferences.js
+++ b/appsrc/components/preferences.js
@@ -189,7 +189,7 @@ export class Preferences extends Component {
           <div className='default-switch hint--right' data-hint={t('preferences.install_location.' + (isDefault ? 'is_default' : 'make_default'))}>
             <span className='single-line'>{path}</span>
             {isDefault
-              ? <span className='single-line default-state'>{t('preferences.install_location.is_default_short')}</span>
+              ? <span className='single-line default-state'>({t('preferences.install_location.is_default_short').toLowerCase()})</span>
               : null
             }
           </div>

--- a/appsrc/components/preferences.js
+++ b/appsrc/components/preferences.js
@@ -189,7 +189,7 @@ export class Preferences extends Component {
           <div className='default-switch hint--right' data-hint={t('preferences.install_location.' + (isDefault ? 'is_default' : 'make_default'))}>
             <span className='single-line'>{path}</span>
             {isDefault
-              ? <span className='single-line default-state'>(default location)</span>
+              ? <span className='single-line default-state'>{t('preferences.install_location.is_default_short')}</span>
               : null
             }
           </div>

--- a/appsrc/style/pages/hub/_preferences.scss
+++ b/appsrc/style/pages/hub/_preferences.scss
@@ -232,6 +232,11 @@ $pref-border-color: $zambezi;
         width: 100%;
       }
 
+      .default-state {
+        color: #999;
+        margin-left: 8px;
+      }
+
       .icon {
         -webkit-filter: brightness(70%);
       }


### PR DESCRIPTION
Fixeds #941.

Adds a (default location) string next to the default location. __Needs translations__

![screen shot 2016-11-02 at 22 10 15](https://cloud.githubusercontent.com/assets/65468/19953985/04f916cc-a14a-11e6-932b-3e60887c024b.png)
