### PR TITLE
Use setVisualZoomLevelLimits instead of setZoomLevelLimits in chrome.tsx

### DIFF
--- a/appsrc/chrome.tsx
+++ b/appsrc/chrome.tsx
@@ -78,7 +78,7 @@ document.addEventListener("click", (e: MouseEvent) => {
 
 if (os.platform() === "darwin") {
   try {
-    require("electron").webFrame.setZoomLevelLimits(1, 1);
+    require("electron").webFrame.setVisualZoomLevelLimits(1, 1);
   } catch (e) {
     console.log(`couldn't disable two-finger zoom: ${e.stack || e}`); // tslint:disable-line:no-console
   }


### PR DESCRIPTION
When building on Arch Linux with electron 1.4.10, I get the following error:

> Running "ts:default" (ts) task
> Compiling...
> Using tsc v2.2.0-dev.20161114
> appsrc/chrome.tsx(81,34): error TS2339: Property 'setZoomLevelLimits' does not exist on type 'WebFrame'.
> 
> 1 non-emit-preventing type warning  
> Error: tsc return code: 2
> Warning: Task "ts:default" failed. Use --force to continue.
> 
> Aborted due to warnings.

[setZoomLevelLimits was deprecated in electron 1.4.8](https://github.com/electron/electron/releases/tag/v1.4.8) and [replaced with setVisualZoomLevelLimits](https://github.com/electron/electron/blob/master/docs/api/web-frame.md#webframesetzoomlevellimitsminimumlevel-maximumlevel). Using the new name fixes the issue for me.