### PR TITLE
fix invalid .desktop file

### DIFF
--- a/release/templates/itch.desktop.in
+++ b/release/templates/itch.desktop.in
@@ -1,12 +1,11 @@
 [Desktop Entry]
 Type=Application
-Encoding=UTF-8
 Name={{APPNAME}}
 TryExec={{APPNAME}}
 Exec={{APPNAME}} %U
 Icon={{APPNAME}}
 Terminal=false
-Categories=Game
-MimeType=x-scheme-handler/{{APPNAME}}io
+Categories=Game;
+MimeType=x-scheme-handler/{{APPNAME}}io;
 X-GNOME-Autostart-enabled=true
 Comment=Install and play itch.io games easily


### PR DESCRIPTION
It's invalid according to desktop-file-validate:
```
$ desktop-file-validate itch.desktop
itch.desktop: warning: key "Encoding" in group "Desktop Entry" is deprecated
itch.desktop: error: value "Game" for string list key "Categories" in group "Desktop Entry" does not have a semicolon (';') as trailing character
itch.desktop: error: value "x-scheme-handler/{{APPNAME}}io" for string list key "MimeType" in group "Desktop Entry" does not have a semicolon (';') as trailing character
```