### PR TITLE
Remove z-index from icon

### DIFF
--- a/appsrc/style/pages/hub/_sidebar.scss
+++ b/appsrc/style/pages/hub/_sidebar.scss
@@ -234,7 +234,6 @@
     flex-shrink: 0;
     margin: 0 6px 0 0px;
     font-size: 90%;
-    z-index: 100;
   }
 
   .label {


### PR DESCRIPTION
Removing z-index from the icon property in `_sidebar.scss` fixes #1136 without altering layouts.