### PR TITLE
 Added optional OS field for App Manifests 

### DIFF
--- a/docs/integrating/manifest.md
+++ b/docs/integrating/manifest.md
@@ -117,11 +117,33 @@ The `args` field can be used to specify arguments to pass to executables.
 
 It must be a TOML array:
 
-```
+```toml
 [[actions]]
 name = "A lot of arguments"
 path = "sample.exe"
 args = ["--that", "--is", "--a", "lot=of-arguments"]
+```
+
+### Operating Systems
+
+The `os` field can be used to specify which operating system an action
+applies to. This allows you to create a single `.itch.toml` that can
+ship with both a Windowsand MacOS build, for example. Actions with
+`"windows"` set will not appear on MacOS, etc.
+
+An action without an `os` field will appear on all operating systems. If present,
+`os` must be set to a valid OS such as `"windows"`, `"macos"`, or `"linux"`
+
+```toml
+[[actions]]
+name = "Launch Windows version - hidden on MacOS and Linux"
+path = "sample.exe"
+os = "windows"
+
+[[actions]]
+name = "Launch MacOS version - hidden on Windows and Linux"
+path = "sample.app"
+os = "macos"
 ```
 
 ### Sandbox opt-in

--- a/docs/integrating/manifest.md
+++ b/docs/integrating/manifest.md
@@ -128,7 +128,7 @@ args = ["--that", "--is", "--a", "lot=of-arguments"]
 
 The `os` field can be used to specify which operating system an action
 applies to. This allows you to create a single `.itch.toml` that can
-ship with both a Windowsand MacOS build, for example. Actions with
+ship with both a Windows and MacOS build, for example. Actions with
 `"windows"` set will not appear on MacOS, etc.
 
 An action without an `os` field will appear on all operating systems. If present,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -140,6 +140,9 @@ export interface IManifestAction {
   /** file path (relative to manifest), URL, etc. */
   path: string;
 
+  /** OS name, valid options are windows, linux, osx, and anything starting with mac */
+  os: string;
+
   /** icon name (see static/fonts/icomoon/demo.html, don't include `icon-` prefix) */
   icon: string;
 


### PR DESCRIPTION
Fixes: https://github.com/itchio/itch/issues/1587

However, this patch is incomplete, Itch debug log shows:

    in manifest action [ActionNameHere], unknown field 'os' found

I don't know how to stop those error messages. I tried adding an entry to `src/types/index.ts` but it didn't work. ~~I suggest you merge and apply the (hopefully simple) fix.~~

What this patch doesn't do is automatically start if only one option for your OS is available. Itch already launches if only one option in total exists.

    case 1:
      return manifest.actions[0];

I'm not sure how to best implement that, but it's a low priority, because as you said, "if it doesn't [require actions besides "play"], you don't need a manifest at all".

![manifest](https://user-images.githubusercontent.com/1646875/34710083-89d8008a-f4df-11e7-918e-0e334ae75138.png)

This is what my test manifest looks like. Actions like "Red Alert" actually exist thrice, once for each OS, but only the action for the relevant OS appears. The "manual" action at the bottom does not contain an OS property, it only exists once in the manifest, and should show up everywhere.

Additionally, Itch will warn devs if the OS property contains something invalid.

Also, I have not tested this on MacOS, as I do not own a Mac. 

I hope that `cave-commands` is an appropriate branch. I noticed that this is the branch you've been working on, so I figured I would push it there.

