### PR TITLE
Use shutdown endpoint to restart butlerd. Fixes #2032

### DIFF
--- a/src/common/butlerd/messages.ts
+++ b/src/common/butlerd/messages.ts
@@ -19,6 +19,13 @@ export interface MetaFlowParams {
 }
 
 /**
+ * Params for Meta.Shutdown
+ */
+export interface MetaShutdownParams {
+  // no fields
+}
+
+/**
  * Payload for MetaFlowEstablished
  */
 export interface MetaFlowEstablishedNotification {
@@ -100,6 +107,21 @@ export interface MetaFlowResult {
 export const MetaFlow = createRequest<MetaFlowParams, MetaFlowResult>(
   "Meta.Flow"
 );
+
+/**
+ * Result for Meta.Shutdown
+ */
+export interface MetaShutdownResult {
+  // no fields
+}
+
+/**
+ * When called, gracefully shutdown the butler daemon.
+ */
+export const MetaShutdown = createRequest<
+  MetaShutdownParams,
+  MetaShutdownResult
+>("Meta.Shutdown");
 
 /**
  * Result for Version.Get

--- a/src/main/reactors/setup.ts
+++ b/src/main/reactors/setup.ts
@@ -142,8 +142,8 @@ async function initialSetup(store: Store, { retry }: { retry: boolean }) {
 interface ButlerIncarnation {
   id: number;
   instance: Instance;
-  convo: Conversation;
   closed: boolean;
+  client: Client;
 }
 
 let butlerInstanceSeed = 1;
@@ -162,8 +162,8 @@ async function refreshButlerd(store: Store) {
   let incarnation: ButlerIncarnation = {
     id,
     instance,
-    convo: null,
     closed: false,
+    client: null,
   };
 
   instance
@@ -196,9 +196,9 @@ async function refreshButlerd(store: Store) {
     `...for butlerd instance ${id} got endpoint ${endpoint.http.address}`
   );
 
-  const client = new Client(endpoint);
+  incarnation.client = new Client(endpoint);
 
-  const versionInfo = await client.call(messages.VersionGet, {});
+  const versionInfo = await incarnation.client.call(messages.VersionGet, {});
   logger.info(
     `Now speaking with butlerd instance ${id}, version ${
       versionInfo.versionString
@@ -206,8 +206,7 @@ async function refreshButlerd(store: Store) {
   );
 
   if (previousIncarnation) {
-    let client = new Client(await previousIncarnation.instance.getEndpoint());
-    await client.call(messages.MetaShutdown, {});
+    await previousIncarnation.client.call(messages.MetaShutdown, {});
   }
   previousIncarnation = incarnation;
 

--- a/src/main/reactors/setup.ts
+++ b/src/main/reactors/setup.ts
@@ -197,22 +197,6 @@ async function refreshButlerd(store: Store) {
   );
 
   const client = new Client(endpoint);
-  const flowEstablished = new Promise<Conversation>((resolve, reject) => {
-    setTimeout(() => {
-      reject(new Error(`Meta.Flow call timed out for butlerd instance ${id}!`));
-    }, 2000);
-
-    client
-      .call(messages.MetaFlow, {}, convo => {
-        // TODO: listen for global notifications here
-        convo.on(messages.MetaFlowEstablished, async () => {
-          logger.info(`Meta.Flow established for butlerd instance ${id}!`);
-          resolve(convo);
-        });
-      })
-      .catch(reject);
-  });
-  incarnation.convo = await flowEstablished;
 
   const versionInfo = await client.call(messages.VersionGet, {});
   logger.info(
@@ -222,31 +206,8 @@ async function refreshButlerd(store: Store) {
   );
 
   if (previousIncarnation) {
-    let inc = previousIncarnation;
-    let beforeCancel = Date.now();
-    if (inc.convo) {
-      logger.info(
-        `Requesting graceful shutdown of butlerd instance ${inc.id}...`
-      );
-      inc.convo.cancel();
-    }
-
-    if (inc.instance) {
-      logger.debug(`Waiting for butlerd instance ${inc.id} to close...`);
-      let interval: NodeJS.Timer;
-      let intervalMs = 1000;
-      interval = setInterval(() => {
-        let elapsed = Date.now() - beforeCancel;
-        if (inc.closed) {
-          logger.info(
-            `butlerd instance ${
-              inc.id
-            } exited! (${elapsed.toFixed()} ms after shutdown request)`
-          );
-          clearInterval(interval);
-        }
-      }, intervalMs);
-    }
+    let client = new Client(await previousIncarnation.instance.getEndpoint());
+    await client.call(messages.MetaShutdown, {});
   }
   previousIncarnation = incarnation;
 


### PR DESCRIPTION
Amos had to hold my hand a lot but I got there eventually!

To break it down:
- butlerd lifecycle was dependent on an ongoing connection to the 'flow' endpoint, which would usually be terminated by the itch app when we wanted to restart butler (due to an update)
- However, the connection could also be killed when Windows goes to sleep, in which case butlerd would terminate gracefully but no new instance would be created to take its place
- To fix this, we no longer use the flow endpoint, but instead call the shutdown endpoint to explicitly request a graceful shutdown of butlerd