### PR TITLE
Long titles

### DIFF
--- a/src/renderer/basics/GameStats.tsx
+++ b/src/renderer/basics/GameStats.tsx
@@ -46,6 +46,12 @@ const GameStatsDiv = styled.div`
     }
   }
 
+  .total-playtime--line {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
   .total-playtime,
   .last-playthrough {
     font-size: ${props => props.theme.fontSizes.baseText};
@@ -56,6 +62,11 @@ const GameStatsDiv = styled.div`
 const GameTitle = styled.div`
   font-weight: 700;
   line-height: 120%;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  white-space: normal;
 `;
 
 const SpacedPlatformIcons = styled(PlatformIcons)`

--- a/src/renderer/basics/GameStats.tsx
+++ b/src/renderer/basics/GameStats.tsx
@@ -10,6 +10,14 @@ import TimeAgo from "renderer/basics/TimeAgo";
 import TotalPlaytime from "renderer/basics/TotalPlaytime";
 import styled from "renderer/styles";
 import { T } from "renderer/t";
+import { browserContextHeight } from "renderer/pages/BrowserPage/BrowserContext/BrowserContextConstants";
+import {
+  standardCoverHeight,
+  standardCoverWidth,
+} from "renderer/pages/common/StandardGameCover";
+
+const coverFactor = browserContextHeight / standardCoverHeight;
+const smallerCoverWidth = coverFactor * standardCoverWidth;
 
 const GameStatsDiv = styled.div`
   display: flex;
@@ -19,6 +27,7 @@ const GameStatsDiv = styled.div`
   line-height: 1.8;
   flex-shrink: 0;
   justify-content: flex-end;
+  max-width: calc(100% - ${smallerCoverWidth + 16 + 160 + 16 + 48}px);
 
   div {
     margin-right: 12px;
@@ -46,6 +55,7 @@ const GameStatsDiv = styled.div`
 
 const GameTitle = styled.div`
   font-weight: 700;
+  line-height: 120%;
 `;
 
 const SpacedPlatformIcons = styled(PlatformIcons)`


### PR DESCRIPTION
This prevents long titles (like light novel titles, for instance) from causing
the `GameStats` to push the MainAction and manage game buttons off-screen, and
instead wrap words. The line wrapping for the title is limited to two lines. All lines in the `GameStats` are truncated with ellipses to prevent ugly vertical overflow.

Before:
<img width="1045" alt="screen shot 2018-10-31 at 21 40 26" src="https://user-images.githubusercontent.com/1690225/47835223-37b21880-dd79-11e8-920b-0a6de65064d0.png">

After:
<img width="1026" alt="screen shot 2018-11-01 at 01 55 16" src="https://user-images.githubusercontent.com/1690225/47835231-3da7f980-dd79-11e8-95e7-95ce919a869d.png">

Truncating text on a *very* narrow window to prevent overflow:
<img width="537" alt="screen shot 2018-11-01 at 02 13 18" src="https://user-images.githubusercontent.com/1690225/47835737-d770a600-dd7b-11e8-90f7-752839f6d0d4.png">

Fixes #2185