### PR TITLE
:arrow_up: Upgrade Electron to 8.3.0.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3216,9 +3216,9 @@
       "dev": true
     },
     "electron": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-7.0.0.tgz",
-      "integrity": "sha512-vrF1loRW1p0vQCbduqO0EZpo8ePJOuxUT6tSoUSU3lsbGK3VnlJop+0PpCIPzbe2K4G4Gk7WexH08V9se7mJcA==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-8.3.0.tgz",
+      "integrity": "sha512-XRjiIJICZCgUr2vKSUI2PTkfP0gPFqCtqJUaTJSfCTuE3nTrxBKOUNeRMuCzEqspKkpFQU3SB3MdbMSHmZARlQ==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",
@@ -3849,15 +3849,15 @@
       }
     },
     "extract-zip": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
-      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
+      "integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
       "dev": true,
       "requires": {
-        "concat-stream": "1.6.2",
-        "debug": "2.6.9",
-        "mkdirp": "0.5.1",
-        "yauzl": "2.4.1"
+        "concat-stream": "^1.6.2",
+        "debug": "^2.6.9",
+        "mkdirp": "^0.5.4",
+        "yauzl": "^2.10.0"
       },
       "dependencies": {
         "debug": {
@@ -3869,22 +3869,19 @@
             "ms": "2.0.0"
           }
         },
-        "fd-slicer": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-          "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
-          "dev": true,
-          "requires": {
-            "pend": "~1.2.0"
-          }
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
         },
-        "yauzl": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
-          "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "dev": true,
           "requires": {
-            "fd-slicer": "~1.0.1"
+            "minimist": "^1.2.5"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "codecov": "^3.5.0",
     "cross-env": "^5.2.0",
     "css-loader": "^3.0.0",
-    "electron": "^7.0.0",
+    "electron": "^8.3.0",
     "electron-notarize": "^0.1.1",
     "electron-packager": "^14.0.6",
     "file-loader": "^4.0.0",


### PR DESCRIPTION
I'm trying to make the Itch client accessible under Linux and the Orca screen reader. The minimum version of Electron needed for this is 7.1.0.

Electron 8.0 includes additional accessibility improvements, so I went with 8.3. If this introduces other problems, though, then I'd request that we upgrade to at least 7.1.

Other access improvements are still needed, but without an Electron version bump, Itch is entirely inaccessible under Linux.

Thanks!