### PR TITLE
Expose Itch object to HTML games using contextBridge

### DIFF
--- a/src/main/inject/inject-game.ts
+++ b/src/main/inject/inject-game.ts
@@ -1,6 +1,6 @@
 import querystring from "querystring";
 import urlParser from "url";
-import { webFrame } from "electron";
+import { contextBridge } from "electron";
 
 declare function atob(b64: string): string;
 
@@ -12,11 +12,6 @@ interface Itch {
   env: Env;
   args: string[];
 }
-
-type ExtendedGlobal = typeof global & {
-  Itch: Itch;
-};
-const extendedGlobal = global as ExtendedGlobal;
 
 (function () {
   try {
@@ -42,9 +37,10 @@ const extendedGlobal = global as ExtendedGlobal;
     const jsonSource = atob(
       Array.isArray(itchObjectBase64) ? itchObjectBase64[0] : itchObjectBase64
     );
-    extendedGlobal.Itch = JSON.parse(jsonSource);
+    const Itch: Itch = JSON.parse(jsonSource);
+    contextBridge.exposeInMainWorld("Itch", Itch);
     console.log("Loaded itch environment!");
-    console.dir(extendedGlobal.Itch);
+    console.dir(Itch);
   } catch (e) {
     console.error("While loading itch environment: ", e);
   } finally {


### PR DESCRIPTION
Fixes #2703 

Basically, the "Itch" global wasn't getting exposed to my installed HTML5 game code when launched from the Itch app because of [Electron's context isolation](https://www.electronjs.org/docs/tutorial/context-isolation) (it sounds like the existing code that modifies "global" used to work due to a bug in context isolation).

This change uses Electron's [contextBridge.exposeInMainWorld](https://www.electronjs.org/docs/api/context-bridge#contextbridgeexposeinmainworldapikey-api-experimental) function to expose the "Itch" global that is created in the (isolated) preload script.

I tested with [two](https://github.com/fasterthanlime/sample-html-app) [different](https://github.com/jaredkrinke/itch-html5-api-sample) HTML integration samples (which threw an "Itch is undefined" error before) to ensure that the "Itch" global (with API key) was exposed with this fix.

I observed this issue originally on Windows 10, and I only tested this change on Windows 10. I don't currently have access to any other operating systems.

EDIT: The following paragraph is about a different (but related) issue, that appears to be an Electron bug.

Having said that, neither of the samples appear to have API requests that actually work. The [Itch documentation](https://itch.io/docs/itch/integrating/manifest-actions.html) indicates that the "same origin policy" is disabled for HTML5 games launched from the app, but I saw CORS errors in the console. EDIT: The origin issue looks like it was a bug in Electron that was recently fixed (the Itch App code correctly sets `webPreferences.webSecurity` to false): https://github.com/electron/electron/issues/23664