### PR TITLE
Remove dependency on webContents.history

### DIFF
--- a/src/common/constants/urls.ts
+++ b/src/common/constants/urls.ts
@@ -1,4 +1,4 @@
-const originalItchio = "https://itch.io";
+const originalItchio = "https://itch.io/";
 const itchio = process.env.WHEN_IN_ROME || originalItchio;
 const manual = "https://itch.io/docs/itch";
 const itchRepo = "https://github.com/itchio/itch";


### PR DESCRIPTION
The history field of Electron's webContents module is no longer present
beyond Electron 10, so we have to stop using it in order to upgrade.

webContents.history is used to manage a subset of browsing history
within the app. My observation is that the global history (which
includes itch:// URLs) is a superset of the webContents.history, so the
theory is that we could rely entirely on the global history and
back-forward navigation would work just as well.

Closes #2598