### PR TITLE
Recognize arm64 as a valid goarch

### DIFF
--- a/src/main/broth/platform.ts
+++ b/src/main/broth/platform.ts
@@ -16,6 +16,8 @@ export function goarch() {
     return "amd64";
   } else if (result === "ia32") {
     return "386";
+  } else if (result === "arm64") {
+    return "arm64";
   } else {
     return "unknown";
   }


### PR DESCRIPTION
The itch app queries the OS for its platform architecture in order to decide which builds of butler and itch-setup to download from broth.itch.ovh. There is a bit of ad-hoc logic in the itch app to translate the architecture string into the format used by Go, which is what butler and itch-setup are written in and packaged with. This ad-hoc logic did not recognize arm64 as a valid architecture, likely because broth.itch.ovh does not currently serve arm64 builds of butler and itch-setup. This commit prepares the itch app for a future where such builds are available.