### PR TITLE
Ampersand fix for issue 2890

### DIFF
--- a/src/main/reactors/context-menu.ts
+++ b/src/main/reactors/context-menu.ts
@@ -46,6 +46,13 @@ export default function (watcher: Watcher) {
     const { wind, template, clientX, clientY } = action.payload;
     const nw = getNativeWindow(rs, wind);
 
+    // Replaces single ampersands to allow them to show up in context menus.
+    // See issue #2890
+    template[0].localizedLabel[1].title = template[0].localizedLabel[1].title.replace(
+      "&",
+      "&&"
+    );
+
     const menu = Menu.buildFromTemplate(convertTemplate(store, template));
     menu.popup({
       window: nw,

--- a/src/main/reactors/context-menu.ts
+++ b/src/main/reactors/context-menu.ts
@@ -47,7 +47,7 @@ export default function (watcher: Watcher) {
     const nw = getNativeWindow(rs, wind);
 
     // Replaces single ampersands to allow them to show up in context menus.
-    // See issue #2890
+    // See issue #2890 for context
     template[0].localizedLabel[1].title = template[0].localizedLabel[1].title.replace(
       "&",
       "&&"


### PR DESCRIPTION
As in the title, fixes #2890 by properly escaping ampersands in context menus.  Tested and it seems to work well for other games with ampersands in the title, and doesn't seem to affect launching.  Tested on Ubuntu 22.04.2 LTS with the latest development version.

![image](https://github.com/itchio/itch/assets/12357690/1c22a46b-9053-4f7f-b940-4cbd2b72dd26)
![image](https://github.com/itchio/itch/assets/12357690/410c4a76-70f2-4eec-9440-5a109870e67c)
