### PR TITLE
:bug: Remove slash duplication in user profile URLs

### DIFF
--- a/src/common/constants/urls.ts
+++ b/src/common/constants/urls.ts
@@ -1,4 +1,4 @@
-const originalItchio = "https://itch.io/";
+const originalItchio = "https://itch.io";
 const itchio = process.env.WHEN_IN_ROME || originalItchio;
 const manual = "https://itch.io/docs/itch";
 const itchRepo = "https://github.com/itchio/itch";


### PR DESCRIPTION
## Summary

Fixes slash duplication in user profile URLs. 

![https://itch.io/profile/botamochi0x12](https://github.com/itchio/itch/assets/35482739/e6560b56-6539-4ecc-9b1f-815d84f27395)

## Cause & Impact

The bug arises from a double slash in the path, resulting in URLs like `https://itch.io//profile/the-user-name`.
The constant `originalItchio` includes the trailing slash.

> <img alt="image" width="1343" src="https://private-user-images.githubusercontent.com/4474501/290994553-05251a19-9a7a-4f52-8794-06c79e3ebcd1.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTU3Nzk4NjEsIm5iZiI6MTcxNTc3OTU2MSwicGF0aCI6Ii80NDc0NTAxLzI5MDk5NDU1My0wNTI1MWExOS05YTdhLTRmNTItODc5NC0wNmM3OWUzZWJjZDEucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI0MDUxNSUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNDA1MTVUMTMyNjAxWiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9Y2U2ZWIyYmUyNWNiY2Y3NTg2MTljODYyMTJhN2IzMGFhMmUxMDZkYjI4ZmQxMjFkM2ZiMGQ1ZDliYmU3MmU2NyZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QmYWN0b3JfaWQ9MCZrZXlfaWQ9MCZyZXBvX2lkPTAifQ.iJu1DNBfTK5bWwdamwXKKHB7SC2g4AxlScOXdJCTz_4">
> -- from itchio/itch/issues/2975

## Considerations

As mentioned in [the issue #2975](https://github.com/itchio/itch/issues/2975), other paths may also be affected. Introducing a package to construct URLs from bare strings could address this issue more comprehensively.
