### PR TITLE
Adding Colons to Protocol Check per 3236

### DIFF
--- a/src/main/reactors/launch/perform-html-launch.ts
+++ b/src/main/reactors/launch/perform-html-launch.ts
@@ -128,7 +128,7 @@ export async function performHTMLLaunch(
 
   win.webContents.setWindowOpenHandler(({ url }) => {
     let u = new URL(url);
-    if (u.protocol == "http" || u.protocol == "https") {
+    if (u.protocol == "http:" || u.protocol == "https:") {
       shell.openExternal(url);
     } else {
       logger.warn(`Prevented opening external URL: ${url}`);


### PR DESCRIPTION
Addresses issue #3236.  Protocol check was missing colons, confirmed via local testing that colons are indeed returned by that url.protocol variable.
![Screenshot from 2025-02-07 19-09-40](https://github.com/user-attachments/assets/f040fb1c-6a9f-423b-a1a9-dd012f0ed9f7)
